### PR TITLE
Update base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
-ARG BASE_IMAGE=gcr.io/distroless/static:nonroot
+# We need the cp command to copy files to shared volumes
+ARG BASE_IMAGE=busybox:1.32
 
 FROM golang:1.13 as builder
 ARG LDFLAGS


### PR DESCRIPTION
update base image to busybox, because it needs `cp` command in that case

```yaml
apiVersion: v1
kind: Pod
metadata:
  name: primehub-monitoring-agent-demo
spec:
  containers:
  - name: notebook
    image: jupyter/base-notebook
    ports:
    - containerPort: 8888
    volumeMounts:
    - name: tools
      mountPath: /tools
    command:
    - bash
    - -c
    - |
      /tools/primehub-monitoring-agent
      jupyter notebook
  initContainers:
  - name: install-agent
    image: infuseai/primehub-monitoring-agent:v0.1
    command: ["cp", "/primehub-monitoring-agent", "/tools"]
    volumeMounts:
    - name: tools
      mountPath: "/tools"
  dnsPolicy: Default
  volumes:
  - name: tools
    emptyDir: {}
```

```
Events:
  Type     Reason     Age              From                                  Message
  ----     ------     ----             ----                                  -------
  Normal   Scheduled  14s              default-scheduler                     Successfully assigned default/primehub-monitoring-agent-demo to dev-ssssssss-kubeadm-centos7
  Normal   Pulling    13s              kubelet, dev-ssssssss-kubeadm-centos7  Pulling image "infuseai/primehub-monitoring-agent:v0.1"
  Normal   Pulled     8s               kubelet, dev-ssssssss-kubeadm-centos7  Successfully pulled image "infuseai/primehub-monitoring-agent:v0.1"
  Normal   Pulled     7s               kubelet, dev-ssssssss-kubeadm-centos7  Container image "infuseai/primehub-monitoring-agent:v0.1" already present on machine
  Normal   Created    6s (x2 over 8s)  kubelet, dev-ssssssss-kubeadm-centos7  Created container install-agent
  Warning  Failed     6s (x2 over 8s)  kubelet, dev-ssssssss-kubeadm-centos7  Error: failed to start container "install-agent": Error response from daemon: OCI runtime create failed: container_linux.go:349: starting container process caused "exec: \"cp\": executable file not found in $PATH": unknown
```